### PR TITLE
Add apiID to Configuration

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -47,6 +47,13 @@ final class Configuration
     private $username;
 
     /**
+     * The API interface ID in Zaaksysteem
+     *
+     * @var integer
+     */
+    private $apiID;
+
+    /**
      * @param array $configuration Array with configuration settings
      * @throws InvalidArgumentException
      */
@@ -61,6 +68,11 @@ final class Configuration
         Assertion::notEmptyKey($configuration, 'username', 'username is required');
         Assertion::string($configuration['username'], 'username has to be a string');
         $this->username = trim($configuration['username']);
+
+        // Validate api interface id
+        Assertion::notEmptyKey($configuration, 'apiID', 'apiID is required');
+        Assertion::integer($configuration['apiID'], 'apiID has to be an integer');
+        $this->apiID = trim($configuration['apiID']);
 
         // Validate api key
         Assertion::notEmptyKey($configuration, 'apiKey', 'apiKey is required');
@@ -104,6 +116,14 @@ final class Configuration
     public function getUsername()
     {
         return $this->username;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getApiID()
+    {
+        return $this->apiID;
     }
 
 }

--- a/tests/Helpers/ConfigurationHelperTrait.php
+++ b/tests/Helpers/ConfigurationHelperTrait.php
@@ -20,7 +20,8 @@ trait ConfigurationHelperTrait
             [
                 'apiBaseUrl' => 'http://foobar.com',
                 'username' => 'foo bar',
-                'apiKey' => 'api key'
+                'apiKey' => 'api key',
+                'apiID' => 42
             ],
             $configuration
         );


### PR DESCRIPTION
The API interface ID is needed for the "External Koppelprofiel" base URI.
This URI is https://hostname/public/<api_id>/<object_type>

For our API v1 the header Api-Interface-Id is needed to talk to our API. On
environments where there is one API v1 this header is not needed. When
there are multiple v1 API's configured this header becomes mandatory.
